### PR TITLE
Fix bug in leap year handling

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,9 +8,9 @@ const hasCorrectChecksum = (input: string, checksum: string) => {
 };
 
 const hasValidDate = (input: string) => {
-  let [_, dayStr, monthStr, yearStr] = /^(\d{2})(\d{2})(\d{2})/.exec(input);
-
-  const year = Number(yearStr);
+  let [_, dayStr, monthStr, yearStr, centuryChar] = /^(\d{2})(\d{2})(\d{2})(.)/.exec(input);
+  const centuryMap = { '+': 1800, '-': 1900, A: 2000 }
+  const year = Number(yearStr) + centuryMap[centuryChar];
   const month = Number(monthStr) - 1;
   const day = Number(dayStr);
   const date = new Date(year, month, day);
@@ -18,7 +18,7 @@ const hasValidDate = (input: string) => {
   const yearIsValid = String(date.getFullYear()).substr(-2) === yearStr;
   const monthIsValid = date.getMonth() === month;
   const dayIsValid = date.getDate() === day;
-
+  console.log(dayIsValid, monthIsValid, yearIsValid, date)
   return yearIsValid && monthIsValid && dayIsValid;
 };
 
@@ -30,5 +30,5 @@ export const isValid = (input: string) => {
   const cleaned = input.substr(0, 10).replace(/\D/g, '');
   const checksum = input.substr(-1).toUpperCase();
 
-  return hasCorrectChecksum(cleaned, checksum) && hasValidDate(cleaned);
+  return hasCorrectChecksum(cleaned, checksum) && hasValidDate(input);
 };

--- a/test.js
+++ b/test.js
@@ -16,6 +16,7 @@ test('personal identity codes with a correct checksum but incorrect date', asser
   assert.notOk(isValid('310253-4947'));
   assert.notOk(isValid('301388-3605'));
   assert.notOk(isValid('320988-676d'));
+  assert.notOk(isValid('290200-8912'));
   assert.end();
 });
 
@@ -25,5 +26,6 @@ test('valid personal identity codes', assert => {
   assert.ok(isValid('160853-494c'));
   assert.ok(isValid('100688-360L'));
   assert.ok(isValid('260988-676J'));
+  assert.ok(isValid('290200A8912')); // year 2000 leap day
   assert.end();
 });


### PR DESCRIPTION
Javascript year object converts the year 00 to year 1900 and year 1900 but year 1900 was skipped, so 290200 is parsed to date 28.02.1900 which makes the validation to fail.

Heres a link to some kind of explanation why the leap year didnt happen on 1900
https://docs.microsoft.com/en-us/office/troubleshoot/excel/determine-a-leap-year